### PR TITLE
Do not use space if no card is displayed

### DIFF
--- a/state-switch.js
+++ b/state-switch.js
@@ -51,7 +51,12 @@ class StateSwitch extends cardTools.LitElement {
       this.currentCard = ((state)?this.cards[state.state]:null)
         || this.cards[this.config.default];
     }
-
+    
+    if (!this.currentCard) {
+      this.style.margin = 0;
+    } else {
+      this.style.margin = undefined;
+    }
     if(this.currentCard != lastCard) this.requestUpdate();
   }
 


### PR DESCRIPTION
If no card is displayed, state-switch is using 8px total (4 on top and 4 on bottom). This should fix it.