### PR TITLE
fix: Skip state update when cards have not been initialized

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -12,7 +12,7 @@ class StateSwitch extends LitElement {
   @property() state;
   @property() _tmpl;
 
-  #cardsInitialized = false;
+  cardsInitialized = false;
 
   cards: Record<string, LovelaceCard>;
   _mqs: MediaQueryList[];
@@ -79,13 +79,13 @@ class StateSwitch extends LitElement {
       this.cards[k] = await helpers.createCardElement(this._config.states[k]);
       this.cards[k].hass = this._hass;
     }
-    this.#cardsInitialized = true;
+    this.cardsInitialized = true;
     this.update_state();
   }
 
   update_state() {
     // skip state update when cards have not been fully initialized yet
-    if (!this.#cardsInitialized) {
+    if (!this.cardsInitialized) {
       return;
     }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,8 @@ class StateSwitch extends LitElement {
   @property() state;
   @property() _tmpl;
 
+  #cardsInitialized = false;
+
   cards: Record<string, LovelaceCard>;
   _mqs: MediaQueryList[];
 
@@ -77,10 +79,16 @@ class StateSwitch extends LitElement {
       this.cards[k] = await helpers.createCardElement(this._config.states[k]);
       this.cards[k].hass = this._hass;
     }
+    this.#cardsInitialized = true;
     this.update_state();
   }
 
   update_state() {
+    // skip state update when cards have not been fully initialized yet
+    if (!this.#cardsInitialized) {
+      return;
+    }
+
     let newstate = undefined;
     switch (this._config.entity) {
       case "template":


### PR DESCRIPTION
The cards from `states` are initialized async. The first state update can sporadically trigger before all cards have been initialized (maybe depending on the cards' complexity?).

When the state has been determined, no further state change is triggered (the reactive property `state` has correctly been set to the default value). But as the cards are not initialized yet, state-switch will display nothing (`no-match`), as it cannot find any card matching the state's value.

This PR leaves the `state` untouched, unless the cards have been fully initialized.

Fixes [!61](https://github.com/thomasloven/lovelace-state-switch/issues/61)