### PR TITLE
feat: add ignore_missing option

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -125,8 +125,13 @@ class StateSwitch extends LitElement {
         }
     }
 
-    if (newstate === undefined || !this.cards.hasOwnProperty(newstate))
+
+    if (newstate === undefined || !this.cards.hasOwnProperty(newstate)) {
+      if (this._config.ignore_missing && this.state !== undefined) {
+        return;
+      }
       newstate = this._config.default;
+    }
     this.state = newstate;
   }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,6 +7,8 @@ export interface StateSwitchConfig {
 
   transition: string;
   transition_time: number;
+
+  ignore_missing?: boolean;
 }
 
 export interface LovelaceCard extends HTMLElement {


### PR DESCRIPTION
This PR adds a new `ignore_missing` boolean option to the card configuration.

When the current state dynamically changes to a value that is not defined in the `states` list, the card defaults to the `default` view. If `ignore_missing: true` is set, the card will instead ignore the change and keep displaying the current matched card. This is particularly useful when cycling through specific states without wanting the UI to jump to a default view if an intermediate state isn't mapped.

#### Changes:
- Added `ignore_missing` logic in `update_state()` inside `src/main.ts`.
- Added `ignore_missing` property to `StateSwitchConfig` in `src/types.ts`.